### PR TITLE
docs: fix typos across READMEs, CONTRIBUTING, and UNLICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ The intent and goal of open sourcing this project is to increase the contributor
 
 ## Salesforce Sponsored
 
-The intent and goal of open sourcing this project is to increase the contributor and user base. However, only Salesforce employees will be given `admin` rights and will be the final arbitrars of what contributions are accepted or not.
+The intent and goal of open sourcing this project is to increase the contributor and user base. However, only Salesforce employees will be given `admin` rights and will be the final arbitrators of what contributions are accepted or not.
 
 > or
 
@@ -25,7 +25,7 @@ The intent and goal of open sourcing this project is because it may contain usef
 
 # Getting started
 
-Please join the community on {Here list Slack channels, Email lists, Glitter, Discord, etc... links}. Also please make sure to take a look at the project [roadmap](ROADMAP.md) to see where are headed.
+Please join the community on {Here list Slack channels, Email lists, Glitter, Discord, etc... links}. Also please make sure to take a look at the project [roadmap](ROADMAP.md) to see where we are headed.
 
 # Issues, requests & ideas
 
@@ -48,9 +48,9 @@ Use GitHub Issues page to submit issues, enhancement requests and discuss ideas.
 
 ### Tests, Documentation, Miscellaneous
 -  If you'd like to improve the tests, you want to make the documentation clearer, you have an
-   alternative implementation of something that may have advantages over the way its currently
+   alternative implementation of something that may have advantages over the way it's currently
    done, or you have any other change, we would be happy to hear about it!
-  -  If its a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
+  -  If it's a trivial change, go ahead and [send a Pull Request](#creating_a_pull_request) with the changes you have in mind.
   -  If not, [open an Issue](https://github.com/{project_slug}/issues/new) to discuss the idea first.
 
 If you're new to our project and looking for some way to make your first contribution, look for
@@ -65,7 +65,7 @@ Issues labelled `good first contribution`.
   - Comments on complex blocks of code or algorithms (include references to sources).
 - [x] Tests
   - The test suite, if provided, must be complete and pass
-  - Increase code coverage, not versa.
+  - Increase code coverage, not vice versa.
   - Use any of our testkits that contains a bunch of testing facilities you would need. For example: `import com.salesforce.op.test._` and borrow inspiration from existing tests.
 - [x] Dependencies
   - Minimize number of dependencies.

--- a/UNLICENSE.md
+++ b/UNLICENSE.md
@@ -7,7 +7,7 @@ means.
 In jurisdictions that recognize copyright laws, the author or authors
 of this software dedicate any and all copyright interest in the
 software to the public domain. We make this dedication for the benefit
-of the public at large and to the daetriment of our heirs and
+of the public at large and to the detriment of our heirs and
 successors. We intend this dedication to be an overt act of
 relinquishment in perpetuity of all present and future rights to this
 software under copyright law.

--- a/templates/bootstrap2/README.md
+++ b/templates/bootstrap2/README.md
@@ -23,7 +23,7 @@ Copy the template folder to your workspace and perform the following action:
 2. Copy the `template.params.tfvars.json` file content into another json file (we will use `params.tfvars.json` to refer to this copy).
 3. Fill the `params.tfvars.json` file with your own parameters. You will find more information about each parameter in the `Terraform parameters file` section
 4. To execute the script in order to create parameters, please use the following commands on your terminal:
-    * If it's the first time use execute this specific instance of the template, use the following command to initialize terraform providers: 
+    * If it's the first time use, execute this specific instance of the template, use the following command to initialize terraform providers: 
       ```shell
       $ terraform init  
       ```
@@ -31,14 +31,14 @@ Copy the template folder to your workspace and perform the following action:
       ```shell
       $ terraform apply -var-file="params.tfvars.json"
       ```
-      Terraform will show you all the actions that it is going to perform and will ask for you validation. 
+      Terraform will show you all the actions that it is going to perform and will ask for your validation. 
     * To destroy the resources you've previously created, use the following:
       ```shell
       $ terraform destroy -var-file="params.tfvars.json"
       ```
 
 ## Resource creation and recycling
-When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resource that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
+When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resources that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
 
 ![alt text](resources/terraform_plan.png "Terraform plan")
 
@@ -46,7 +46,7 @@ When Terraform applies changes, the `tfstate` file is updated to save the latest
 
 When Terraform is executed for update, it will compare against its latest state to refresh and recycle all resources. 
 
-> **N.B:** If the resource have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
+> **N.B:** If the resources have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
 
 ## Terraform parameters file
 The parameters file is used to contextualize terraform's execution. Following is the list of parameters
@@ -83,7 +83,7 @@ Following is the description of the columns in the `csv/users.csv` file:
 | username      | the username of the user, it must be unique and shouldn't be used twice (even if the user has been deleted) | userxx1 |
 | firstname     | the user's firstname | john |
 | lastname      | the user's lastname  | doe  |
-| email         | the usere's email address | my@email.com |
+| email         | the user's email address | my@email.com |
 | phone         | the user's phone number   | 0121231232   |
 | pwd           | the user's initial password | mysupersecurepwd |
 
@@ -107,7 +107,7 @@ Following is the description of the columns in the `csv/teams_roles.csv` file:
 | name          | the role's name | API Group Administrator |
 | context_env_index | if the role spans environments, then provide the environment's name to which the role will be applied against | INT |
 
-Roles will be bind by default to the root org (provided in parameters)
+Roles will be bound by default to the root org (provided in parameters)
 
 #### Team Members
 Following is the description of the columns in the `csv/teams_members.csv` file:

--- a/templates/govcloud/README.md
+++ b/templates/govcloud/README.md
@@ -24,7 +24,7 @@ Copy the template folder to your workspace and perform the following action:
 2. Copy the `template.params.tfvars.json` file content into another json file (we will use `params.tfvars.json` to refer to this copy).
 3. Fill the `params.tfvars.json` file with your own parameters. You will find more information about each parameter in the `Terraform parameters file` section
 4. To execute the script in order to create parameters, please use the following commands on your terminal:
-    * If it's the first time use execute this specific instance of the template, use the following command to initialize terraform providers: 
+    * If it's the first time use, execute this specific instance of the template, use the following command to initialize terraform providers: 
       ```shell
       $ terraform init  
       ```
@@ -32,14 +32,14 @@ Copy the template folder to your workspace and perform the following action:
       ```shell
       $ terraform apply -var-file="params.tfvars.json"
       ```
-      Terraform will show you all the actions that it is going to perform and will ask for you validation. 
+      Terraform will show you all the actions that it is going to perform and will ask for your validation. 
     * To destroy the resources you've previously created, use the following:
       ```shell
       $ terraform destroy -var-file="params.tfvars.json"
       ```
 
 ## Resource creation and recycling
-When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resource that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
+When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resources that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
 
 ![alt text](resources/terraform_plan.png "Terraform plan")
 
@@ -47,7 +47,7 @@ When Terraform applies changes, the `tfstate` file is updated to save the latest
 
 When Terraform is executed for update, it will compare against its latest state to refresh and recycle all resources. 
 
-> **N.B:** If the resource have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
+> **N.B:** If the resources have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
 
 ## Terraform parameters file
 The parameters file is used to contextualize terraform's execution. Following is the list of parameters
@@ -87,7 +87,7 @@ Following is the description of the columns in the `csv/users.csv` file:
 | username      | the username of the user, it must be unique and shouldn't be used twice (even if the user has been deleted) | userxx1 |
 | firstname     | the user's firstname | john |
 | lastname      | the user's lastname  | doe  |
-| email         | the usere's email address | my@email.com |
+| email         | the user's email address | my@email.com |
 | phone         | the user's phone number   | 0121231232   |
 | pwd           | the user's initial password | mysupersecurepwd |
 
@@ -111,7 +111,7 @@ Following is the description of the columns in the `csv/teams_roles.csv` file:
 | name          | the role's name | API Group Administrator |
 | context_env_index | if the role spans environments, then provide the environment's name to which the role will be applied against | INT |
 
-Roles will be bind by default to the root org (provided in parameters)
+Roles will be bound by default to the root org (provided in parameters)
 
 #### Team Members
 Following is the description of the columns in the `csv/teams_members.csv` file:

--- a/templates/mvp/README.md
+++ b/templates/mvp/README.md
@@ -24,7 +24,7 @@ Copy the template folder to your workspace and perform the following action:
 2. Copy the `template.params.tfvars.json` file content into another json file (we will use `params.tfvars.json` to refer to this copy).
 3. Fill the `params.tfvars.json` file with your own parameters. You will find more information about each parameter in the `Terraform parameters file` section
 4. To execute the script in order to create parameters, please use the following commands on your terminal:
-    * If it's the first time use execute this specific instance of the template, use the following command to initialize terraform providers: 
+    * If it's the first time use, execute this specific instance of the template, use the following command to initialize terraform providers: 
       ```shell
       $ terraform init  
       ```
@@ -32,14 +32,14 @@ Copy the template folder to your workspace and perform the following action:
       ```shell
       $ terraform apply -var-file="params.tfvars.json"
       ```
-      Terraform will show you all the actions that it is going to perform and will ask for you validation. 
+      Terraform will show you all the actions that it is going to perform and will ask for your validation. 
     * To destroy the resources you've previously created, use the following:
       ```shell
       $ terraform destroy -var-file="params.tfvars.json"
       ```
 
 ## Resource creation and recycling
-When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resource that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
+When the terraform script is executed, terraform compiles your parameters to know exactly what it is going to create and in which order. Following is a schema that shows the resources that are created. Arrows show dependency relationship. Terraform will start by creating the roots and make its way down through dependencies. 
 
 ![alt text](resources/terraform_plan.png "Terraform plan")
 
@@ -47,7 +47,7 @@ When Terraform applies changes, the `tfstate` file is updated to save the latest
 
 When Terraform is executed for update, it will compare against its latest state to refresh and recycle all resources. 
 
-> **N.B:** If the resource have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
+> **N.B:** If the resources have been changed outside terraform (using anypoint UI for example) terraform will not include those changes, and they will be lost.
 
 ## Terraform parameters file
 The parameters file is used to contextualize terraform's execution. Following is the list of parameters
@@ -84,7 +84,7 @@ Following is the description of the columns in the `csv/users.csv` file:
 | username      | the username of the user, it must be unique and shouldn't be used twice (even if the user has been deleted) | userxx1 |
 | firstname     | the user's firstname | john |
 | lastname      | the user's lastname  | doe  |
-| email         | the usere's email address | my@email.com |
+| email         | the user's email address | my@email.com |
 | phone         | the user's phone number   | 0121231232   |
 | pwd           | the user's initial password | mysupersecurepwd |
 
@@ -108,7 +108,7 @@ Following is the description of the columns in the `csv/teams_roles.csv` file:
 | name          | the role's name | API Group Administrator |
 | context_env_index | if the role spans environments, then provide the environment's name to which the role will be applied against | INT |
 
-Roles will be bind by default to the root org (provided in parameters)
+Roles will be bound by default to the root org (provided in parameters)
 
 #### Team Members
 Following is the description of the columns in the `csv/teams_members.csv` file:


### PR DESCRIPTION
## Summary
- Fix 6 recurring typos across 3 template READMEs (govcloud, mvp, bootstrap2):
  `you validation` → `your`, `usere's` → `user's`, `resource that/have` → `resources` (×2), `be bind` → `be bound`, `use execute` → `use, execute`
- Fix 5 typos in CONTRIBUTING.md: `arbitrars` → `arbitrators`, `not versa` → `not vice versa`, `where are headed` → `where we are headed`, `its` → `it's` (×2)
- Fix 1 typo in UNLICENSE.md: `daetriment` → `detriment`

## Test plan
- Documentation-only changes — no code modifications
- Verified each typo exists in the current default branch before fixing